### PR TITLE
add encryption_type and file_extension to content obj

### DIFF
--- a/controller/create_record.go
+++ b/controller/create_record.go
@@ -15,6 +15,8 @@ type CreateRecordRequest struct {
 	PaymentTokenAddress string `json:"payment_token_address"`
 	PaymentTokenAmount  int64  `json:"payment_token_amount"`
 	KeyID               int64  `json:"key_id"`
+	EncryptionType      int8   `json:"encryption_type"`
+	FileExtension       string `json:"file_extension"`
 }
 
 type CreateRecordResponse struct {
@@ -33,7 +35,7 @@ func create_record(c *gin.Context) {
 		return
 	}
 
-	content, err := model.CreateRecord(req.ContentLocateUrl, req.ManagedContract, req.KeyID)
+	content, err := model.CreateRecord(req.ContentLocateUrl, req.ManagedContract, req.KeyID, req.EncryptionType, req.FileExtension)
 	if err != nil {
 		errorResp(c, http.StatusInternalServerError, xerrors.Errorf("Error in DB: %w", err))
 		return

--- a/model/content.go
+++ b/model/content.go
@@ -8,12 +8,17 @@ import (
 const VALID_STATUS = 1
 const INVALID_STATUS = 0
 
+const ENCRYPTION_TYPE_AES = 1
+const ENCRYPTION_TYPE_ECC = 2
+
 type Content struct {
 	ID              int64 `gorm:"primarykey"`
 	ManagedContract string
 	CreatorAddress  string
+	EncryptionType  int8 `gorm:"default:1"`
 	KeyID           int64
 	LocationUrl     string
+	FileExtension   string
 	Status          int8 `gorm:"default:1"`
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
@@ -31,12 +36,14 @@ func FindContentByID(ID int64) (content *Content, err error) {
 	return content, nil
 }
 
-func CreateRecord(LocateUrl string, managedContract string, keyID int64) (content *Content, err error) {
+func CreateRecord(locateUrl string, managedContract string, keyID int64, encryptionType int8, fileExtension string) (content *Content, err error) {
 	c := &Content{}
 	c.KeyID = keyID
 	c.ManagedContract = managedContract
-	c.LocationUrl = LocateUrl
+	c.LocationUrl = locateUrl
 	c.CreatorAddress = GetTxAccAddr().String()
+	c.EncryptionType = encryptionType
+	c.FileExtension = fileExtension
 	tx := DB.Create(c)
 	if tx.Error != nil {
 		return nil, xerrors.Errorf("error when creating a content record: %w", tx.Error)

--- a/model/contract.go
+++ b/model/contract.go
@@ -21,9 +21,8 @@ func CreateAsset(contentId int64, contractAddr string, tokenAddr string, tokenAm
 	tx_acc := GetTxAccSK()
 	transactOps, err := bind.NewKeyedTransactorWithChainID(tx_acc, GetChainID())
 	tx, err := conn.CreateAsset(transactOps, uint64(contentId), common.HexToAddress(tokenAddr), big.NewInt(tokenAmount))
-
 	if err != nil {
-		return xerrors.Errorf("failed to create the content asset through contract, err:%v, tx:%s", err, tx.Hash().String())
+		return xerrors.Errorf("failed to create the content asset through contract, err:%v, tx:%v", err, tx)
 	}
 	return nil
 }

--- a/util/encrypt/encrypt.go
+++ b/util/encrypt/encrypt.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"strings"
 
@@ -17,19 +18,40 @@ import (
 
 // EncryptContentByPublicKey Encrypt content using the public key
 // Returns the encrypted content file path
-func EncryptContentByPublicKey(content string, publicKey string) (string, error) {
+func EncryptPasswordByPublicKey(password string, publicKey string) (string, error) {
 	publicKey = strings.TrimPrefix(publicKey, "04")
 	if publicKey == "" || len(publicKey) != 128 {
 		return "", fmt.Errorf("invalid public key")
 	}
-	if content == "" {
+	if password == "" {
 		return "", fmt.Errorf("invalid input content")
 	}
 	keyByte, err := DerivePublicKey(publicKey)
 	if err != nil {
 		return "", err
 	}
-	encryptDataByte, err := EciesEncrypt([]byte(content), keyByte)
+	encryptDataByte, err := EciesEncrypt([]byte(password), keyByte)
+	if err != nil {
+		return "", err
+	}
+	return hexutil.Encode(encryptDataByte), nil
+}
+
+func EncryptContentByPublicKey(filePath string, publicKey string) (string, error) {
+	publicKey = strings.TrimPrefix(publicKey, "04")
+	if publicKey == "" || len(publicKey) != 128 {
+		return "", fmt.Errorf("invalid public key")
+	}
+	keyByte, err := DerivePublicKey(publicKey)
+	if err != nil {
+		return "", err
+	}
+	bytes, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("invalid public key")
+	}
+	fmt.Printf("content bytes: %s", bytes)
+	encryptDataByte, err := EciesEncrypt(bytes, keyByte)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Add encryption type and file extension to the content record.
 Based on that, 
- add those two fields to the content model 
- get-content API gives different encrypted content by different encryption type 


